### PR TITLE
Use latest beautifulsoup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4==4.5.1
+beautifulsoup4==4.11.1
 xlrd==1.0.0
 flask>=0.12.3
 argparse==1.4.0


### PR DESCRIPTION
This enables support for python 3.10, and should still work with python 3.6+ according to the BeautifulSoup website.

Fixes #17